### PR TITLE
Update CVE-2025-8194.json

### DIFF
--- a/osv/python/CVE-2025-8194.json
+++ b/osv/python/CVE-2025-8194.json
@@ -19,7 +19,7 @@
           "type": "SEMVER",
           "events": [
             {
-              "introduced": "3.13.0"
+              "introduced": "0"
             },
             {
               "fixed": "3.13.6"


### PR DESCRIPTION
This one actually has a 0 as the `introduced` version value, see https://github.com/psf/advisory-database/blob/f9490e062b737d43ad5168f404dfbb7283a98c0a/advisories/python/PSF-2025-11.json#L17