### PR TITLE
docs: clarify VEX discovery paths

### DIFF
--- a/integration/current-production/README.md
+++ b/integration/current-production/README.md
@@ -27,9 +27,24 @@ security scanners with Docker Hardened Images (DHI).
 
 - **Integration FAQ**: [docs/faq.md](docs/faq.md)
 - **OSV Feed**: `https://github.com/docker-hardened-images/advisories/tree/main/osv/`
-- **VEX Feed**: `https://github.com/docker-hardened-images/advisories/tree/main/vex/`
+- **VEX by image repository**: `https://github.com/docker-hardened-images/advisories/tree/main/vex/`
+- **VEX by package**: `https://github.com/docker-hardened-images/advisories/blob/main/index.json`
 - **OpenVEX Spec**: `https://openvex.dev/`
 - **OCI Referrers**: `https://github.com/opencontainers/distribution-spec/blob/main/spec.md#listing-referrers`
+
+## VEX Sources
+
+Scanner integrations can sync `index.json` and the referenced documents under
+`pkg/` for package-oriented VEX discovery.
+
+The repository also provides other views and distribution paths:
+
+- `vex/<image-repository>/dhi-<image-repository>.vex.json` is organized by DHI
+  image repository. It is not tied to one image tag or digest.
+- OCI referrers provide VEX and SBOM attestations attached to an image digest.
+
+Use the scanned image's package inventory or SBOM to determine which VEX
+products apply.
 
 ---
 

--- a/integration/current-production/docs/decision-trees.md
+++ b/integration/current-production/docs/decision-trees.md
@@ -64,17 +64,20 @@ graph TD
 
 ```mermaid
 graph TD
-    A[Get VEX Statements] --> B[Option 1: Comprehensive VEX]
-    A --> C[Option 2: OCI Referrers]
-    
-    B --> B1[Fetch from GitHub:<br/>dhi.vex.json]
-    
-    C --> C1[Same as SBOM process]
-    C1 --> C2[Find OpenVEX predicate]
-    
+    A[Get VEX Statements] --> B[Sync GitHub VEX Repository]
+    A --> C[Use OCI Referrers]
+
+    B --> B1[Read index.json and pkg/]
+
+    C --> C1[Resolve Selected Platform Digest]
+    C1 --> C2[Find OpenVEX Predicate]
+
     B1 --> D[VEX Statements Ready]
     C2 --> D
 ```
+
+`vex/<image-repository>/` is also available for image-repository lookup. It is
+not tied to one image tag or digest.
 
 ### Step 3: OSV Feed Access
 

--- a/integration/current-production/docs/faq.md
+++ b/integration/current-production/docs/faq.md
@@ -81,12 +81,17 @@ We could, but transparency is more valuable. With dual feeds:
 
 ### Do we need to support OCI 1.1 referrers?
 
-**Recommended but not required initially.**
+**Not for a feed-based integration.**
 
-**Option 1 (Simpler)**: Use comprehensive VEX feed from GitHub  
-**Option 2 (Better)**: Use OCI referrers for image-specific SBOM/VEX
+Scanner partners can periodically sync `index.json` and the referenced `pkg/`
+documents rather than query OCI referrers for every image. OCI referrers remain
+available when image-attached SBOM and VEX attestations are useful.
 
-Most partners start with Option 1, add Option 2 later.
+### Which GitHub VEX path should I use?
+
+Use `vex/<image-repository>/` for image-repository lookup. Use `index.json` and
+`pkg/` for package-oriented scanner discovery. Use the scanned image's package
+inventory or SBOM to determine which VEX products apply.
 
 ---
 
@@ -103,7 +108,7 @@ Most partners start with Option 1, add Option 2 later.
 
 **Level 1 (Basic)**:
 - ✅ Detect DHI images via `/etc/os-release`
-- ✅ Load comprehensive VEX feed
+- ✅ Sync VEX documents through `index.json` and `pkg/`
 - ✅ Apply VEX to suppress false positives and record status/justification
 - ✅ Route `pkg:dhi/*` to OSV feed
 


### PR DESCRIPTION
## Summary

- document `index.json` and `pkg/` as the feed-based package discovery path
- distinguish the image-repository view under `vex/` from package-oriented discovery
- keep OCI referrers as an optional source of image-attached SBOM and VEX attestations
- update the FAQ and decision tree to remove the obsolete consolidated VEX guidance

## Validation

- `git diff --check origin/main...HEAD`
- confirmed the current-production guide no longer references `dhi.vex.json` or a comprehensive VEX file