### PR TITLE
docs: explain derived DHI base discovery

### DIFF
--- a/integration/README.md
+++ b/integration/README.md
@@ -30,6 +30,9 @@ reference anchors used by the examples in this guide.
 
 The model-specific guides define the integration contract. The one-page
 overview is explanatory and should not be used as a separate routing contract.
+Both models use the same
+[derived-image base-discovery procedure](derived-image-base-discovery.md) when
+a scanner needs the Docker-issued SBOM for a customer image's DHI base.
 
 ## New Model Summary
 
@@ -56,7 +59,7 @@ comparison, but it is not the advisory namespace for DHI-owned OS packages.
 | Stage | Image state | Advisory state | Scanner expectation |
 | --- | --- | --- | --- |
 | Before first cutover | All production images use the current-production model. | Existing advisories repo artifacts remain live. | Use the current-production guide. Upcoming examples are local-only fixtures. |
-| First family cutover | One or more published image families report `ID=dhi`. Publication of that cutover image is the readiness signal. | Generated DHI advisory data is already available for the image and its contents. | For official images, match packages against the Docker-issued OCI-referrer SBOM attached to the resolved platform digest. For derived images, establish DHI origin through chain-ID/layer attribution or a known base's Docker-issued SBOM. Route packages not attributed to DHI through normal upstream Alpine or Debian coverage. For an eligible DHI package, no matching affected range means no matching vulnerability. Keep current-production handling for non-cutover families. |
+| First family cutover | One or more published image families report `ID=dhi`. Publication of that cutover image is the readiness signal. | Generated DHI advisory data is already available for the image and its contents. | For official images, match packages against the Docker-issued OCI-referrer SBOM attached to the resolved platform digest. For derived images, establish DHI origin through chain-ID/layer attribution or a verified base SBOM resolved through the documented base-discovery procedure. Route packages not attributed to DHI through normal upstream Alpine or Debian coverage. For an eligible DHI package, no matching affected range means no matching vulnerability. Keep current-production handling for non-cutover families. |
 | Mixed production | Both models are live. | Each published `ID=dhi` image has corresponding generated advisory data; existing advisory artifacts remain live for non-cutover images. | Detect per image and per package, and retain the corresponding product-membership check for DHI advisory routing. Do not assume all DHI images have moved. |
 | Completed cutover | DHI base layers consistently report `ID=dhi`. | Generated DHI OSV and VEX data is the normal advisory surface. | Retire current-production-only detection and VEX overlay assumptions. |
 
@@ -65,5 +68,6 @@ comparison, but it is not the advisory namespace for DHI-owned OS packages.
 - [One-page overview: DHI scanner integration upcoming changes](dhi-scanner-integration-upcoming-changes.md)
 - [Current production guide](current-production/README.md)
 - [Upcoming `ID=dhi` guide](upcoming-id-dhi/README.md)
+- [Derived-image base discovery](derived-image-base-discovery.md)
 - [OpenVEX Spec](https://openvex.dev/)
 - [OCI Referrers](https://github.com/opencontainers/distribution-spec/blob/main/spec.md#listing-referrers)

--- a/integration/current-production/README.md
+++ b/integration/current-production/README.md
@@ -12,12 +12,14 @@ security scanners with Docker Hardened Images (DHI).
 ## 🎯 Quick Start
 
 1. Review the [Decision Trees](docs/decision-trees.md)
-2. Read the DHI docs to explore or get real images:
+2. For derived images, review
+   [base discovery](../derived-image-base-discovery.md)
+3. Read the DHI docs to explore or get real images:
    - [Explore DHI images](https://docs.docker.com/dhi/how-to/explore/)
    - [Mirror DHI images](https://docs.docker.com/dhi/how-to/mirror/)
-3. Run the [Go Reference Implementation](reference-implementations/go/)
-4. Try the [Example Images](examples/)
-5. Validate using the [Test Suite](validation/test-suite.md)
+4. Run the [Go Reference Implementation](reference-implementations/go/)
+5. Try the [Example Images](examples/)
+6. Validate using the [Test Suite](validation/test-suite.md)
 
 ## 🚀 Reference Implementation
 
@@ -26,6 +28,8 @@ security scanners with Docker Hardened Images (DHI).
 ## 📄 Resources
 
 - **Integration FAQ**: [docs/faq.md](docs/faq.md)
+- **Derived-image base discovery**:
+  [../derived-image-base-discovery.md](../derived-image-base-discovery.md)
 - **OSV Feed**: `https://github.com/docker-hardened-images/advisories/tree/main/osv/`
 - **VEX Feed**: `https://github.com/docker-hardened-images/advisories/tree/main/vex/`
 - **OpenVEX Spec**: `https://openvex.dev/`

--- a/integration/current-production/docs/decision-trees.md
+++ b/integration/current-production/docs/decision-trees.md
@@ -60,6 +60,12 @@ graph TD
     D3 --> E
 ```
 
+For a derived image, an SBOM attached to or generated from the customer image
+describes its final contents; it does not prove which packages came from DHI.
+Base-image referrers are not inherited by the derived image. Follow
+[derived-image base discovery](../../derived-image-base-discovery.md) before
+using a Docker-issued base SBOM as package-origin evidence.
+
 ### Step 2: VEX Retrieval
 
 ```mermaid
@@ -182,9 +188,9 @@ graph TD
 graph TD
     A[Derived Image: Need to Validate Package Origin] --> B{Which Method?}
     
-    B -->|Method A: SBOM Comparison| C[Fetch DHI Base SBOM]
-    C --> C1[Use chainID to identify base boundary]
-    C1 --> C2[Compare: Package in base?]
+    B -->|Method A: SBOM Comparison| C[Resolve candidate base digest<br/>from provenance or supplied input]
+    C --> C1[Verify base diff IDs are a prefix<br/>and ChainID matches boundary]
+    C1 --> C2[Fetch base SBOM via referrers]
     C2 --> C3{PURL + Version<br/>match exactly?}
     C3 -->|Yes| D[From DHI Base<br/>Apply VEX]
     C3 -->|No| E[Customer Modified<br/>No VEX]
@@ -204,6 +210,12 @@ graph TD
     style D fill:#90EE90
     style E fill:#FFB6C6
 ```
+
+The ChainID locates the base-layer boundary but does not identify an OCI
+manifest. Follow the shared
+[derived-image base-discovery procedure](../../derived-image-base-discovery.md)
+to recover a candidate base digest from SLSA provenance and verify it before
+retrieving the Docker-issued base SBOM.
 
 ---
 
@@ -257,8 +269,8 @@ graph TD
 
 ```mermaid
 graph TD
-    A[Scanner Detects chainID] --> B[Fetches DHI Base SBOM]
-    B --> C[Compares Package Lists]
+    A[Scanner Detects chainID] --> B[Resolves and verifies<br/>DHI base digest]
+    B --> C[Fetches base SBOM<br/>and compares packages]
     C --> D{Package in<br/>DHI base?}
     D -->|Yes| E[Apply VEX for this package]
     D -->|No| F[Scan normally, no VEX]

--- a/integration/current-production/docs/faq.md
+++ b/integration/current-production/docs/faq.md
@@ -116,8 +116,8 @@ This gets you 80% of the value.
 **Steps**:
 1. Detect `com.docker.dhi.chain-id` label
 2. Resolve the base layer boundary by matching the chainID against the layer chain
-3. Resolve a candidate DHI base repository, digest, and platform from SLSA
-   provenance or another supplied base reference
+3. Resolve a candidate DHI base repository, digest, and platform from the
+   derived image's SLSA provenance
 4. Verify that the base `rootfs.diff_ids` are an exact prefix of the derived
    image and that the prefix ChainID matches the label
 5. Retrieve the verified base's SBOM via OCI referrers
@@ -126,7 +126,7 @@ This gets you 80% of the value.
 
 The ChainID is not an image digest and cannot be used for OCI referrer lookup.
 See [Derived-image base discovery](../../derived-image-base-discovery.md) for
-the complete procedure and fallback behavior when provenance is unavailable.
+the complete procedure and provenance requirement.
 
 ### What if I can't access GitHub feeds?
 

--- a/integration/current-production/docs/faq.md
+++ b/integration/current-production/docs/faq.md
@@ -116,9 +116,17 @@ This gets you 80% of the value.
 **Steps**:
 1. Detect `com.docker.dhi.chain-id` label
 2. Resolve the base layer boundary by matching the chainID against the layer chain
-3. Retrieve SBOM via OCI referrers (attestation)
-4. Associate SBOM packages to layers (base vs app layers)
-5. Apply VEX only to packages from base layers; scan app layers normally
+3. Resolve a candidate DHI base repository, digest, and platform from SLSA
+   provenance or another supplied base reference
+4. Verify that the base `rootfs.diff_ids` are an exact prefix of the derived
+   image and that the prefix ChainID matches the label
+5. Retrieve the verified base's SBOM via OCI referrers
+6. Associate SBOM packages to layers (base vs app layers)
+7. Apply VEX only to packages from base layers; scan app layers normally
+
+The ChainID is not an image digest and cannot be used for OCI referrer lookup.
+See [Derived-image base discovery](../../derived-image-base-discovery.md) for
+the complete procedure and fallback behavior when provenance is unavailable.
 
 ### What if I can't access GitHub feeds?
 

--- a/integration/current-production/examples/python/derived-image/README.md
+++ b/integration/current-production/examples/python/derived-image/README.md
@@ -101,7 +101,7 @@ docker run --rm test-derived-python
 
 Your scanner should:
 1. Detect chainID
-2. Resolve the base digest from provenance or supplied base identity
+2. Resolve the base digest from the derived image's provenance
 3. Verify the base rootfs prefix and ChainID
 4. Fetch the base SBOM
 5. Apply VEX only to base packages

--- a/integration/current-production/examples/python/derived-image/README.md
+++ b/integration/current-production/examples/python/derived-image/README.md
@@ -58,7 +58,7 @@ Should return: `"com.docker.dhi.chain-id": "sha256:ad3d5af2..."`
 - `pkg:pypi/flask@2.3.0` ← Customer added
 - `pkg:pypi/requests@2.31.0` ← Customer added
 
-**Base image SBOM** (fetch via OCI referrers, using the chainID to identify base layers):
+**Base image SBOM** (resolve and verify the base digest, then fetch its OCI referrer):
 - `pkg:dhi/python@3.13.1`
 - `pkg:apk/alpine/musl@1.2.5-r0`
 - ... other DHI packages
@@ -101,9 +101,11 @@ docker run --rm test-derived-python
 
 Your scanner should:
 1. Detect chainID
-2. Fetch base SBOM
-3. Apply VEX only to base packages
-4. Report Flask CVEs normally
+2. Resolve the base digest from provenance or supplied base identity
+3. Verify the base rootfs prefix and ChainID
+4. Fetch the base SBOM
+5. Apply VEX only to base packages
+6. Report Flask CVEs normally
 
 ## Troubleshooting
 
@@ -114,7 +116,9 @@ Your scanner should:
 **Fix**: Ensure chainID is detected and base SBOM is fetched
 
 **Problem**: Can't fetch base SBOM
-**Fix**: Use OCI referrers for the base image SBOM or map SBOM packages to layers and compare against the chainID boundary (see [Decision Trees](../../../docs/decision-trees.md))
+**Fix**: Follow [Derived-image base discovery](../../../../derived-image-base-discovery.md).
+The ChainID identifies a layer boundary, not the base manifest needed for an
+OCI referrer lookup.
 
 ## Next Steps
 

--- a/integration/current-production/reference-implementations/go/README.md
+++ b/integration/current-production/reference-implementations/go/README.md
@@ -36,6 +36,10 @@ VEX attestation: https://openvex.dev/ns/v0.2.0
 
 - This is a reference implementation; production scanners should add caching, retries, and richer SBOM/VEX parsing.
 - For derived images, use the chainID boundary to decide which packages are from the DHI base before applying VEX.
+- The implementation locates the DHI layer boundary but does not recover the
+  base manifest digest. Follow
+  [Derived-image base discovery](../../../derived-image-base-discovery.md) to
+  resolve and verify the base before retrieving its Docker-issued SBOM.
 
 --- 
 

--- a/integration/derived-image-base-discovery.md
+++ b/integration/derived-image-base-discovery.md
@@ -1,0 +1,134 @@
+<img alt="dhi-banner" src="https://github.com/user-attachments/assets/fc0ca203-3f25-4ae5-aa8e-e3918bbcc31f" />
+
+# DHI Derived-Image Base Discovery
+
+This document defines how a scanner can recover and verify the Docker Hardened
+Images (DHI) base of an OCI-derived customer image. The procedure is shared by
+the [current-production](current-production/README.md) and
+[upcoming `ID=dhi`](upcoming-id-dhi/README.md) scanner models. The models use
+the resulting package-origin evidence differently, but base discovery is the
+same.
+
+This procedure applies to images built `FROM` a DHI image. It does not infer an
+OCI parent for a DHI customization assembled independently from shared build
+instructions.
+
+## Boundary And Base Digest Are Different
+
+A derived image can inherit the `com.docker.dhi.chain-id` label. A scanner can
+recompute cumulative ChainIDs from the final image config's ordered
+`rootfs.diff_ids` and locate the matching DHI base-layer boundary.
+
+The ChainID is not an OCI manifest digest, an image reference, or an OCI
+referrer lookup key. It cannot by itself identify the repository and
+platform-manifest digest needed to retrieve the base image's Docker-issued
+SBOM.
+
+Standard OCI image manifests, configs, and history do not provide a parent
+image lookup. Do not construct a mutable tag from inherited DHI name or version
+labels and assume it identifies the base that was used.
+
+OCI referrers are associated with a specific subject digest. Building a new
+derived image does not reattach the DHI base image's SBOM to the derived image
+digest. The scanner must recover and verify the base platform-manifest digest
+before it can retrieve that base's Docker-issued SBOM.
+
+## Deterministic Provenance Path
+
+When the customer image publishes BuildKit/SLSA provenance containing resolved
+dependencies, use the following procedure:
+
+1. Resolve the customer image to the platform manifest being scanned and
+   retrieve its associated SLSA provenance. Depending on how the image was
+   published, the provenance can be represented as an OCI referrer or an
+   attestation manifest in the image index.
+2. Inspect `predicate.buildDefinition.resolvedDependencies` for DHI OCI image
+   candidates. A BuildKit dependency URI can include the repository from which
+   the base was pulled, its index digest, and the platform. The repository can
+   be `dhi.io` or a customer mirror.
+3. If the dependency digest identifies an image index, resolve the recorded
+   platform to its child platform-manifest digest.
+4. Fetch the candidate DHI platform manifest and config. If the dependency came
+   from a mirror, require the mirror to preserve the manifest and Docker-issued
+   attestations, or resolve the digest to its canonical DHI repository through
+   other trusted metadata.
+5. Verify that the candidate base config's complete `rootfs.diff_ids` list is
+   an exact prefix of the derived image's `rootfs.diff_ids` list.
+6. Compute the ChainID of that prefix and require it to equal the derived
+   image's `com.docker.dhi.chain-id` value.
+7. List OCI referrers for the verified DHI platform-manifest digest and select
+   its Docker-issued SPDX or CycloneDX SBOM.
+8. Use the SBOM together with layer attribution to determine whether each
+   package was inherited unchanged, added, replaced, or modified later.
+
+Treat the provenance dependency as a candidate until the rootfs-prefix and
+ChainID checks pass. Provenance can contain dependencies from multiple build
+stages; do not select a candidate merely because its URI uses `dhi.io` or its
+config carries DHI labels. A digest identifies content, but an OCI Distribution
+API lookup still requires a repository from which the scanner can retrieve the
+manifest and Docker-issued SBOM.
+
+## When Provenance Is Unavailable
+
+Without resolved base provenance, a supplied base reference, or an
+authoritative external mapping, a scanner cannot recover the base manifest
+digest from the derived image. The ChainID can locate the claimed boundary,
+but no OCI registry operation resolves a ChainID back to a manifest.
+
+Valid alternatives are:
+
+- receive the exact DHI base reference and platform from the caller or build
+  system, then perform the prefix and ChainID verification above;
+- use other trusted build provenance that records the DHI base repository,
+  digest, and platform; or
+- use a Docker-published mapping from DHI ChainID and platform to canonical
+  base manifests, if such a service or feed becomes available.
+
+If DHI package origin cannot be established, fail safely:
+
+| Scanner model | Behavior |
+| --- | --- |
+| Current production | Do not apply DHI VEX to suppress a finding whose DHI base origin is unproven. |
+| Upcoming `ID=dhi` | Do not select generated DHI advisory data from the package namespace alone; use the upstream routing defined by the upcoming guide. |
+
+## Verified Example
+
+The upcoming guide's
+[Alpine derived-image fixture](upcoming-id-dhi/examples/e2e-alpine-layer-package-namespace/README.md)
+was built for `linux/arm64` with BuildKit `--provenance=mode=max` from this
+pinned production base:
+
+```text
+dhi.io/bash:5-alpine3.24@sha256:e2b67997780c37dc8352fb3e1bae077497216767cd5edb25c710e3a0fef232ec
+```
+
+The standard derived-image manifest and config inherited this ChainID:
+
+```text
+sha256:a67bcf0f9ddb1dbfde823a9b843e2c59d4428b928e877a95c4750b2ca520c1aa
+```
+
+They did not contain the base index or platform-manifest digest. The separate
+SLSA provenance included the base repository, index digest, and platform:
+
+```text
+pkg:docker/dhi.io/bash@5-alpine3.24?digest=sha256:e2b679...&platform=linux%2Farm64
+```
+
+```text
+base index digest:      sha256:e2b67997780c37dc8352fb3e1bae077497216767cd5edb25c710e3a0fef232ec
+arm64 platform digest:  sha256:c5295aa6c4a01bef0e09e18849089e318d8232ca66ec7ded104baea243dde387
+```
+
+Resolving the index selected the `arm64` platform manifest. Its four
+`rootfs.diff_ids` exactly matched the first four entries in the derived image,
+and their ChainID matched the inherited label. OCI referrer discovery on that
+platform manifest returned the Docker-issued CycloneDX SBOM artifact:
+
+```text
+sha256:b5090997dfad89f60517e59c2ae121543d41a7a26801b640d7d1bd5a3b49f590
+```
+
+This demonstrates both sides of the contract: provenance can supply the base
+digest, while the rootfs prefix and ChainID verify that the derived image
+actually contains that DHI base.

--- a/integration/derived-image-base-discovery.md
+++ b/integration/derived-image-base-discovery.md
@@ -68,28 +68,16 @@ config carries DHI labels. A digest identifies content, but an OCI Distribution
 API lookup still requires a repository from which the scanner can retrieve the
 manifest and Docker-issued SBOM.
 
-## When Provenance Is Unavailable
+## Provenance Requirement
 
-Without resolved base provenance, a supplied base reference, or an
-authoritative external mapping, a scanner cannot recover the base manifest
-digest from the derived image. The ChainID can locate the claimed boundary,
-but no OCI registry operation resolves a ChainID back to a manifest.
+Deterministic derived-image base-SBOM discovery requires published SLSA
+provenance containing the base repository, digest, and platform. If that
+provenance is unavailable, the scanner cannot perform deterministic base-SBOM
+discovery.
 
-Valid alternatives are:
-
-- receive the exact DHI base reference and platform from the caller or build
-  system, then perform the prefix and ChainID verification above;
-- use other trusted build provenance that records the DHI base repository,
-  digest, and platform; or
-- use a Docker-published mapping from DHI ChainID and platform to canonical
-  base manifests, if such a service or feed becomes available.
-
-If DHI package origin cannot be established, fail safely:
-
-| Scanner model | Behavior |
-| --- | --- |
-| Current production | Do not apply DHI VEX to suppress a finding whose DHI base origin is unproven. |
-| Upcoming `ID=dhi` | Do not select generated DHI advisory data from the package namespace alone; use the upstream routing defined by the upcoming guide. |
+ChainID boundary and package-layer attribution remain a separate package-origin
+method defined by the model-specific guides. They do not discover the base
+manifest digest or its Docker-issued SBOM.
 
 ## Verified Example
 

--- a/integration/dhi-scanner-integration-upcoming-changes.md
+++ b/integration/dhi-scanner-integration-upcoming-changes.md
@@ -56,11 +56,13 @@ scanner-generated inventories are not substitutes for that membership SBOM.
 
 For derived images, integrations can establish DHI package origin using the
 existing DHI chain-ID boundary and package layer attribution, or by exact
-package-and-version comparison with the Docker-issued SBOM for a known DHI base
-image. If a package is not attributed to DHI, normalize it to the corresponding
-upstream Alpine or Debian identity and use normal upstream advisory coverage
-with native APK or dpkg version semantics. Namespace alone remains insufficient
-to select DHI advisory data.
+package-and-version comparison with a verified Docker-issued base SBOM. The
+[derived-image base-discovery procedure](derived-image-base-discovery.md)
+explains how published SLSA provenance supplies a candidate base digest and how
+the rootfs prefix and ChainID verify it. If a package is not attributed to DHI,
+normalize it to the corresponding upstream Alpine or Debian identity and use
+normal upstream advisory coverage with native APK or dpkg version semantics.
+Namespace alone remains insufficient to select DHI advisory data.
 
 DHI's internal triage workflow produces the assessments that populate the OSV
 feed. The feed uses [OSV format](https://ossf.github.io/osv-schema/), the same

--- a/integration/upcoming-id-dhi/README.md
+++ b/integration/upcoming-id-dhi/README.md
@@ -35,10 +35,13 @@ publish a cutover image before that data is available.
 
 For a derived image, use the existing DHI chain-ID boundary to attribute
 packages to DHI base layers, or compare exact package and version identities
-with the Docker-issued SBOM for a known DHI base image. Packages whose DHI
-origin cannot be established do not route to generated DHI advisory data from
-their PURL namespace alone; normalize them to the corresponding upstream Alpine
-or Debian identity and use normal upstream advisory coverage.
+with a verified Docker-issued base SBOM. The shared
+[base-discovery procedure](../derived-image-base-discovery.md) explains how
+SLSA provenance supplies a candidate base digest and how to verify it against
+the derived rootfs. Packages whose DHI origin cannot be established do not
+route to generated DHI advisory data from their PURL namespace alone; normalize
+them to the corresponding upstream Alpine or Debian identity and use normal
+upstream advisory coverage.
 
 ## 🎯 Quick Start
 
@@ -48,7 +51,8 @@ or Debian identity and use normal upstream advisory coverage.
 4. Use the [Decision trees](docs/decision-trees.md)
 5. Try the standalone [Alpine](examples/e2e-alpine/README.md) and
    [Debian](examples/e2e-debian/README.md) end-to-end examples
-6. If you scan derived images, try the optional
+6. If you scan derived images, review the shared
+   [base-discovery procedure](../derived-image-base-discovery.md) and try the
    [derived-image routing example](examples/e2e-alpine-layer-package-namespace/README.md)
 7. Validate using the [Validation harness](validation/README.md)
 
@@ -111,8 +115,10 @@ package/version.
 
 > **Derived images:** Treat a package as covered by generated DHI advisory data
 > when chain-ID/layer attribution places it in the DHI base, or when its exact
-> package and version appear in the Docker-issued SBOM for a known DHI base
-> image. The DHI package namespace alone does not establish membership.
+> package and version appear in a verified Docker-issued base SBOM. Use
+> [derived-image base discovery](../derived-image-base-discovery.md) to resolve
+> and verify that base from published provenance. The DHI package namespace
+> alone does not establish membership.
 > Packages outside the DHI base use normal upstream Alpine or Debian advisory
 > coverage with native APK or dpkg version semantics.
 
@@ -160,6 +166,8 @@ integration/upcoming-id-dhi/validation/run-fixture-suite.sh
 - **VEX context**: [docs/vex-context.md](docs/vex-context.md)
 - **Decision trees**: [docs/decision-trees.md](docs/decision-trees.md)
 - **Coverage matrix**: [docs/scenarios.md](docs/scenarios.md)
+- **Derived-image base discovery**:
+  [../derived-image-base-discovery.md](../derived-image-base-discovery.md)
 - **Validation harness**: [validation/README.md](validation/README.md)
 - **OSV Schema**: [https://ossf.github.io/osv-schema/](https://ossf.github.io/osv-schema/)
 - **OpenVEX Spec**: [https://openvex.dev/](https://openvex.dev/)

--- a/integration/upcoming-id-dhi/docs/advisory-routing.md
+++ b/integration/upcoming-id-dhi/docs/advisory-routing.md
@@ -44,7 +44,7 @@ apply generated DHI advisory data from the DHI PURL namespace alone.
 | SBOM package PURL | The concrete package identity that scanner findings and VEX products must match. |
 | Docker-issued SBOM | The full SPDX or CycloneDX OCI-referrer attestation attached to the resolved DHI platform-manifest digest. For an official image, it establishes membership when the exact package and version appear in the SBOM. |
 | DHI chain ID and package layer attribution | For a derived image, identifies the DHI base-layer boundary and packages inherited from those layers. |
-| Known DHI base SBOM | When the exact base image is known, provides another way to establish derived-image membership by exact package-and-version comparison. |
+| Verified DHI base SBOM | Provides another way to establish derived-image membership after the base repository, digest, and platform are resolved and verified against the derived rootfs. |
 
 ## Package Routing
 
@@ -72,16 +72,21 @@ DHI origin checks:
 1. Read `com.docker.dhi.chain-id`, calculate the image's ordered rootfs chain
    IDs, locate the matching DHI base-layer boundary, and attribute packages to
    layers at or before that boundary.
-2. When the exact DHI base image is already known, retrieve its Docker-issued
-   SBOM using its resolved platform-manifest digest and compare exact package
-   and version identities.
+2. Resolve a candidate DHI base repository, digest, and platform from the
+   derived image's SLSA provenance or another supplied base identity. Verify
+   the base `rootfs.diff_ids` as an exact prefix and require its ChainID to
+   match the labeled boundary. Then retrieve its Docker-issued SBOM and compare
+   exact package and version identities.
 
 The chain ID identifies a layer boundary; it is not an image digest or an OCI
-referrer lookup key. If neither method establishes DHI origin, normalize the
-package to the upstream family and release from `ID_LIKE` and `VERSION_ID`, then
-use normal upstream Alpine or Debian advisory coverage with the native package
-manager's version semantics. Do not apply generated DHI advisory data from the
-package namespace alone.
+referrer lookup key. Standard OCI image metadata does not provide a parent
+manifest lookup. See the shared
+[derived-image base-discovery procedure](../../derived-image-base-discovery.md)
+for the deterministic provenance path and fallback behavior. If neither method
+establishes DHI origin, normalize the package to the upstream family and release
+from `ID_LIKE` and `VERSION_ID`, then use normal upstream Alpine or Debian
+advisory coverage with the native package manager's version semantics. Do not
+apply generated DHI advisory data from the package namespace alone.
 
 The [derived-image fixture](../examples/e2e-alpine-layer-package-namespace/README.md)
 demonstrates this boundary with two packages in one final `ID=dhi` image.

--- a/integration/upcoming-id-dhi/docs/advisory-routing.md
+++ b/integration/upcoming-id-dhi/docs/advisory-routing.md
@@ -73,7 +73,7 @@ DHI origin checks:
    IDs, locate the matching DHI base-layer boundary, and attribute packages to
    layers at or before that boundary.
 2. Resolve a candidate DHI base repository, digest, and platform from the
-   derived image's SLSA provenance or another supplied base identity. Verify
+   derived image's SLSA provenance. Verify
    the base `rootfs.diff_ids` as an exact prefix and require its ChainID to
    match the labeled boundary. Then retrieve its Docker-issued SBOM and compare
    exact package and version identities.
@@ -82,7 +82,7 @@ The chain ID identifies a layer boundary; it is not an image digest or an OCI
 referrer lookup key. Standard OCI image metadata does not provide a parent
 manifest lookup. See the shared
 [derived-image base-discovery procedure](../../derived-image-base-discovery.md)
-for the deterministic provenance path and fallback behavior. If neither method
+for the deterministic provenance path and requirement. If neither method
 establishes DHI origin, normalize the package to the upstream family and release
 from `ID_LIKE` and `VERSION_ID`, then use normal upstream Alpine or Debian
 advisory coverage with the native package manager's version semantics. Do not

--- a/integration/upcoming-id-dhi/docs/decision-trees.md
+++ b/integration/upcoming-id-dhi/docs/decision-trees.md
@@ -26,7 +26,7 @@ flowchart TD
   M -->|No| J[Normalize to upstream Alpine or Debian package identity]
   M -->|Yes| D{PURL type}
   N -->|No| J
-  N -->|Chain-ID/layer attribution or known base SBOM match| D
+  N -->|Chain-ID/layer attribution or verified base SBOM match| D
   J --> R[Use normal upstream matching with APK or dpkg version rules]
   D -->|apk| K[Resolve Alpine release from os_version or distro qualifier]
   D -->|deb| L[Resolve Debian release from os_version or distro qualifier]
@@ -38,6 +38,11 @@ flowchart TD
   O -->|Yes| I[Report DHI OSV finding]
   I --> Q[Published paired VEX is optional to consume]
 ```
+
+Resolving a derived image's base SBOM requires more than its ChainID. Follow
+the shared
+[derived-image base-discovery procedure](../../derived-image-base-discovery.md)
+to obtain a candidate digest from provenance and verify the DHI rootfs prefix.
 
 ## VEX Context
 

--- a/integration/upcoming-id-dhi/docs/package-identity-and-versioning.md
+++ b/integration/upcoming-id-dhi/docs/package-identity-and-versioning.md
@@ -79,10 +79,12 @@ For each scanner-observed OS package:
 1. Establish DHI product membership. For an official image, confirm that the
    exact package and version appear in the Docker-issued OCI-referrer SBOM. For
    a derived image, use DHI chain-ID/layer attribution or exact comparison with
-   the Docker-issued SBOM for a known DHI base image. If membership is not
-   established, normalize the package to the upstream family and release from
-   `ID_LIKE` and `VERSION_ID`, use normal upstream advisory coverage with native
-   APK or dpkg version semantics, and stop this DHI matching process.
+   a verified Docker-issued base SBOM resolved through the shared
+   [derived-image base-discovery procedure](../../derived-image-base-discovery.md).
+   If membership is not established, normalize the package to the upstream
+   family and release from `ID_LIKE` and `VERSION_ID`, use normal upstream
+   advisory coverage with native APK or dpkg version semantics, and stop this
+   DHI matching process.
 2. Parse the PURL and require namespace `dhi`.
 3. Read the base lineage and release from `ID_LIKE` and `VERSION_ID`.
 4. Require PURL type `apk` for Alpine or `deb` for Debian.

--- a/integration/upcoming-id-dhi/docs/vex-context.md
+++ b/integration/upcoming-id-dhi/docs/vex-context.md
@@ -101,7 +101,8 @@ Scanners should not need to query upstream Alpine or Debian OSV feeds for a
 DHI-owned base-layer package after generated DHI OSV data exists. When scanning
 derived images, a DHI package PURL does not by itself prove DHI ownership.
 Apply generated DHI OSV/VEX data only when chain-ID/layer attribution places
-the package in the DHI base, or when its exact package and version match the
-Docker-issued SBOM for a known DHI base image. Otherwise, normalize the package
-to its upstream Alpine or Debian identity and use normal upstream advisory
-coverage without DHI VEX.
+the package in the DHI base, or when its exact package and version match a
+verified Docker-issued base SBOM resolved through the shared
+[derived-image base-discovery procedure](../../derived-image-base-discovery.md).
+Otherwise, normalize the package to its upstream Alpine or Debian identity and
+use normal upstream advisory coverage without DHI VEX.

--- a/integration/upcoming-id-dhi/examples/e2e-alpine-layer-package-namespace/README.md
+++ b/integration/upcoming-id-dhi/examples/e2e-alpine-layer-package-namespace/README.md
@@ -53,10 +53,12 @@ package evidence reference resolves to one of them.
 
 In production, a scanner can establish DHI package origin by resolving the
 `com.docker.dhi.chain-id` boundary and attributing packages to DHI base layers.
-If the exact base image is already known, the scanner can instead compare
-against the Docker-issued SPDX or CycloneDX SBOM attached to that base's
-resolved platform-manifest digest. A scanner must not treat an arbitrary SBOM
-supplied with the derived image as a Docker-issued base SBOM.
+It can also resolve a candidate base digest from published SLSA provenance,
+verify the base rootfs prefix and ChainID, and compare against the Docker-issued
+SPDX or CycloneDX SBOM attached to that base's platform-manifest digest. See
+[Derived-image base discovery](../../../derived-image-base-discovery.md). A
+scanner must not treat an arbitrary SBOM supplied with the derived image as a
+Docker-issued base SBOM.
 
 This fixture excludes `jq` because it is absent from the recorded base snapshot
 and its package-file evidence is in later layers. Both observations classify it


### PR DESCRIPTION
## Summary

- define how scanners recover a candidate DHI base digest from published BuildKit/SLSA provenance
- require rootfs diff-ID prefix and ChainID verification before retrieving the base SBOM
- clarify that ChainIDs are not OCI referrer keys and base referrers are not inherited by derived images
- distinguish provenance-based base-SBOM discovery from chain-ID/package-layer attribution
- include the production-backed bash Alpine example used to verify the flow

## Validation

- `integration/upcoming-id-dhi/validation/run-fixture-suite.sh`
- `git diff --check`
- all changed relative Markdown links resolve

## Risk

Documentation only. The new procedure is scoped to OCI-derived images; official-image routing is unchanged.